### PR TITLE
Исправления связанные с работой vk Api

### DIFF
--- a/game_sapper/core/exeptions.py
+++ b/game_sapper/core/exeptions.py
@@ -40,7 +40,7 @@ async def error_handler(error: Exception, request: "Request"):
             message="Internal Server Error",
         )
 
-    request.app.logger.warning(traceback.format_exc() if request.app.settings.traceback else error)
+    request.app.logger.critical(traceback.format_exc() if request.app.settings.traceback else error)
     return error_response
 
 

--- a/game_sapper/store/vk_api/accessor.py
+++ b/game_sapper/store/vk_api/accessor.py
@@ -165,8 +165,10 @@ class VkApiAccessor(BaseAccessor):
         ) as resp:
             data = await resp.json()
             vk_response: VKResponse = VKResponseSchema().load(data)
-            if vk_response.failed == 2:
-                self.logger.warning(f"The session key is outdated, we are updating")
+            if vk_response.failed:
+                self.logger.warning(f"The session key is outdated, we are updating. "
+                                    f"See the api for more details: "
+                                    f"https://dev.vk.com/api/bots-long-poll/getting-started")
                 await self._get_long_poll_service()
                 return []
             self.ts = vk_response.ts


### PR DESCRIPTION
1.  game_sapper/core/exeptions.py - изменен статус лога на ошибки 500, теперь critical
2. game_sapper/store/vk_api/accessor.py : poll : любая ошибка от vk инициализирует _get_long_poll_service